### PR TITLE
Add cache token extraction to genai streaming response

### DIFF
--- a/lib/patches/genai/thinking-blocks-tool-use.patch
+++ b/lib/patches/genai/thinking-blocks-tool-use.patch
@@ -1,8 +1,7 @@
-diff --git a/src/adapter/adapters/anthropic/adapter_impl.rs b/src/adapter/adapters/anthropic/adapter_impl.rs
-index 505a3f3..90fe1f2 100644
---- a/src/adapter/adapters/anthropic/adapter_impl.rs
-+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
-@@ -81,18 +81,36 @@ impl Adapter for AnthropicAdapter {
+diff -ruN a/src/adapter/adapters/anthropic/adapter_impl.rs b/src/adapter/adapters/anthropic/adapter_impl.rs
+--- a/src/adapter/adapters/anthropic/adapter_impl.rs	2025-12-16 02:09:31.446099903 +0000
++++ b/src/adapter/adapters/anthropic/adapter_impl.rs	2025-12-16 02:07:15.837533180 +0000
+@@ -81,18 +81,36 @@
  	) -> Result<WebRequestData> {
  		let ServiceTarget { endpoint, auth, model } = target;
  
@@ -47,7 +46,7 @@ index 505a3f3..90fe1f2 100644
  
  		// -- Parts
  		let AnthropicRequestParts {
-@@ -147,6 +165,36 @@ impl Adapter for AnthropicAdapter {
+@@ -147,6 +165,36 @@
  		});
  
  		if let Some(system) = system {
@@ -84,7 +83,7 @@ index 505a3f3..90fe1f2 100644
  			payload.x_insert("system", system)?;
  		}
  
-@@ -451,6 +499,8 @@ impl AnthropicAdapter {
+@@ -451,6 +499,8 @@
  										"tool_use_id": tool_response.call_id,
  									}));
  								}
@@ -93,7 +92,7 @@ index 505a3f3..90fe1f2 100644
  							}
  						}
  						let values = apply_cache_control_to_parts(is_cache_control, values);
-@@ -458,14 +508,24 @@ impl AnthropicAdapter {
+@@ -458,14 +508,24 @@
  					}
  				}
  
@@ -119,7 +118,7 @@ index 505a3f3..90fe1f2 100644
  							ContentPart::Text(text) => {
  								has_text = true;
  								values.push(json!({"type": "text", "text": text}));
-@@ -486,7 +546,7 @@ impl AnthropicAdapter {
+@@ -486,7 +546,7 @@
  						}
  					}
  
@@ -128,19 +127,18 @@ index 505a3f3..90fe1f2 100644
  						// Optimize to simple string when it's only one text part and no cache control.
  						let text = values
  							.first()
-diff --git a/src/adapter/adapters/anthropic/streamer.rs b/src/adapter/adapters/anthropic/streamer.rs
-index 843f484..d8551c4 100644
---- a/src/adapter/adapters/anthropic/streamer.rs
-+++ b/src/adapter/adapters/anthropic/streamer.rs
+diff -ruN a/src/adapter/adapters/anthropic/streamer.rs b/src/adapter/adapters/anthropic/streamer.rs
+--- a/src/adapter/adapters/anthropic/streamer.rs	2025-12-16 02:09:31.446099903 +0000
++++ b/src/adapter/adapters/anthropic/streamer.rs	2025-12-16 02:08:26.045344310 +0000
 @@ -1,6 +1,6 @@
  use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
  use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
 -use crate::chat::{ChatOptionsSet, ToolCall, Usage};
-+use crate::chat::{ChatOptionsSet, Thinking, ToolCall, Usage};
++use crate::chat::{ChatOptionsSet, PromptTokensDetails, Thinking, ToolCall, Usage};
  use crate::{Error, ModelIden, Result};
  use reqwest_eventsource::{Event, EventSource};
  use serde_json::Value;
-@@ -23,7 +23,7 @@ pub struct AnthropicStreamer {
+@@ -23,7 +23,7 @@
  enum InProgressBlock {
  	Text,
  	ToolUse { id: String, name: String, input: String },
@@ -149,7 +147,7 @@ index 843f484..d8551c4 100644
  }
  
  impl AnthropicStreamer {
-@@ -71,7 +71,10 @@ impl futures::Stream for AnthropicStreamer {
+@@ -71,7 +71,10 @@
  
  							match data.x_get_str("/content_block/type") {
  								Ok("text") => self.in_progress_block = InProgressBlock::Text,
@@ -161,7 +159,7 @@ index 843f484..d8551c4 100644
  								Ok("tool_use") => {
  									self.in_progress_block = InProgressBlock::ToolUse {
  										id: data.x_take("/content_block/id")?,
-@@ -114,18 +117,46 @@ impl futures::Stream for AnthropicStreamer {
+@@ -114,18 +117,46 @@
  									input.push_str(data.x_get_str("/delta/partial_json")?);
  									continue;
  								}
@@ -218,7 +216,7 @@ index 843f484..d8551c4 100644
  								}
  							}
  						}
-@@ -148,6 +179,15 @@ impl futures::Stream for AnthropicStreamer {
+@@ -148,6 +179,15 @@
  
  									return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
  								}
@@ -234,7 +232,7 @@ index 843f484..d8551c4 100644
  								_ => {
  									// no-op for remaining block types
  								}
-@@ -182,6 +222,7 @@ impl futures::Stream for AnthropicStreamer {
+@@ -182,6 +222,7 @@
  								captured_text_content: self.captured_data.content.take(),
  								captured_reasoning_content: self.captured_data.reasoning_content.take(),
  								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -242,7 +240,7 @@ index 843f484..d8551c4 100644
  							};
  
  							// TODO: Need to capture the data as needed
-@@ -193,7 +234,14 @@ impl futures::Stream for AnthropicStreamer {
+@@ -193,7 +234,14 @@
  					}
  				}
  				Some(Err(err)) => {
@@ -258,11 +256,60 @@ index 843f484..d8551c4 100644
  					return Poll::Ready(Some(Err(Error::ReqwestEventSource(err.into()))));
  				}
  				None => return Poll::Ready(None),
-diff --git a/src/adapter/adapters/cohere/streamer.rs b/src/adapter/adapters/cohere/streamer.rs
-index c92bcb0..dc57b50 100644
---- a/src/adapter/adapters/cohere/streamer.rs
-+++ b/src/adapter/adapters/cohere/streamer.rs
-@@ -108,6 +108,7 @@ impl futures::Stream for CohereStreamer {
+@@ -210,10 +258,20 @@
+ 			let data = self.parse_message_data(message_data)?;
+ 			// TODO: Might want to exit early if usage is not found
+ 
+-			let (input_path, output_path) = if message_type == "message_start" {
+-				("/message/usage/input_tokens", "/message/usage/output_tokens")
++			let (input_path, output_path, cache_creation_path, cache_read_path) = if message_type == "message_start" {
++				(
++					"/message/usage/input_tokens",
++					"/message/usage/output_tokens",
++					"/message/usage/cache_creation_input_tokens",
++					"/message/usage/cache_read_input_tokens",
++				)
+ 			} else if message_type == "message_delta" {
+-				("/usage/input_tokens", "/usage/output_tokens")
++				(
++					"/usage/input_tokens",
++					"/usage/output_tokens",
++					"/usage/cache_creation_input_tokens",
++					"/usage/cache_read_input_tokens",
++				)
+ 			} else {
+ 				// TODO: Use tracing
+ 				tracing::debug!(
+@@ -243,6 +301,25 @@
+ 					.get_or_insert(0);
+ 				*val += output_tokens;
+ 			}
++
++			// -- Capture cache token details (Anthropic prompt caching)
++			if let Ok(cache_creation) = data.x_get::<i32>(cache_creation_path) {
++				if cache_creation > 0 {
++					let usage = self.captured_data.usage.get_or_insert(Usage::default());
++					let details = usage.prompt_tokens_details.get_or_insert(PromptTokensDetails::default());
++					let val = details.cache_creation_tokens.get_or_insert(0);
++					*val += cache_creation;
++				}
++			}
++
++			if let Ok(cache_read) = data.x_get::<i32>(cache_read_path) {
++				if cache_read > 0 {
++					let usage = self.captured_data.usage.get_or_insert(Usage::default());
++					let details = usage.prompt_tokens_details.get_or_insert(PromptTokensDetails::default());
++					let val = details.cached_tokens.get_or_insert(0);
++					*val += cache_read;
++				}
++			}
+ 		}
+ 
+ 		Ok(())
+diff -ruN a/src/adapter/adapters/cohere/streamer.rs b/src/adapter/adapters/cohere/streamer.rs
+--- a/src/adapter/adapters/cohere/streamer.rs	2025-12-16 02:09:31.448099927 +0000
++++ b/src/adapter/adapters/cohere/streamer.rs	2025-12-16 02:07:15.838533192 +0000
+@@ -108,6 +108,7 @@
  										captured_text_content: self.captured_data.content.take(),
  										captured_reasoning_content: self.captured_data.reasoning_content.take(),
  										captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -270,11 +317,10 @@ index c92bcb0..dc57b50 100644
  									};
  
  									InterStreamEvent::End(inter_stream_end)
-diff --git a/src/adapter/adapters/gemini/adapter_impl.rs b/src/adapter/adapters/gemini/adapter_impl.rs
-index e232e82..3f1f8d3 100644
---- a/src/adapter/adapters/gemini/adapter_impl.rs
-+++ b/src/adapter/adapters/gemini/adapter_impl.rs
-@@ -458,6 +458,8 @@ impl GeminiAdapter {
+diff -ruN a/src/adapter/adapters/gemini/adapter_impl.rs b/src/adapter/adapters/gemini/adapter_impl.rs
+--- a/src/adapter/adapters/gemini/adapter_impl.rs	2025-12-16 02:09:31.451099961 +0000
++++ b/src/adapter/adapters/gemini/adapter_impl.rs	2025-12-16 02:07:15.838533192 +0000
+@@ -458,6 +458,8 @@
  									}
  								}));
  							}
@@ -283,7 +329,7 @@ index e232e82..3f1f8d3 100644
  						}
  					}
  
-@@ -479,6 +481,7 @@ impl GeminiAdapter {
+@@ -479,6 +481,7 @@
  							// Ignore unsupported parts for Assistant role
  							ContentPart::Binary(_) => {}
  							ContentPart::ToolResponse(_) => {}
@@ -291,11 +337,10 @@ index e232e82..3f1f8d3 100644
  						}
  					}
  					if !parts_values.is_empty() {
-diff --git a/src/adapter/adapters/gemini/streamer.rs b/src/adapter/adapters/gemini/streamer.rs
-index c076ab0..715c720 100644
---- a/src/adapter/adapters/gemini/streamer.rs
-+++ b/src/adapter/adapters/gemini/streamer.rs
-@@ -55,6 +55,7 @@ impl futures::Stream for GeminiStreamer {
+diff -ruN a/src/adapter/adapters/gemini/streamer.rs b/src/adapter/adapters/gemini/streamer.rs
+--- a/src/adapter/adapters/gemini/streamer.rs	2025-12-16 02:09:31.452099973 +0000
++++ b/src/adapter/adapters/gemini/streamer.rs	2025-12-16 02:07:15.839533203 +0000
+@@ -55,6 +55,7 @@
  								captured_text_content: self.captured_data.content.take(),
  								captured_reasoning_content: self.captured_data.reasoning_content.take(),
  								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -303,11 +348,10 @@ index c076ab0..715c720 100644
  							};
  
  							InterStreamEvent::End(inter_stream_end)
-diff --git a/src/adapter/adapters/openai/adapter_impl.rs b/src/adapter/adapters/openai/adapter_impl.rs
-index 3ea3116..7bb85c9 100644
---- a/src/adapter/adapters/openai/adapter_impl.rs
-+++ b/src/adapter/adapters/openai/adapter_impl.rs
-@@ -479,6 +479,8 @@ impl OpenAIAdapter {
+diff -ruN a/src/adapter/adapters/openai/adapter_impl.rs b/src/adapter/adapters/openai/adapter_impl.rs
+--- a/src/adapter/adapters/openai/adapter_impl.rs	2025-12-16 02:09:31.456100019 +0000
++++ b/src/adapter/adapters/openai/adapter_impl.rs	2025-12-16 02:07:15.839533203 +0000
+@@ -479,6 +479,8 @@
  								// TODO: Probably need to warn if it is a ToolCalls type of content
  								ContentPart::ToolCall(_) => (),
  								ContentPart::ToolResponse(_) => (),
@@ -316,7 +360,7 @@ index 3ea3116..7bb85c9 100644
  							}
  						}
  						messages.push(json! ({"role": "user", "content": values}));
-@@ -508,6 +510,8 @@ impl OpenAIAdapter {
+@@ -508,6 +510,8 @@
  							// TODO: Probably need towarn on this one (probably need to add binary here)
  							ContentPart::Binary(_) => (),
  							ContentPart::ToolResponse(_) => (),
@@ -325,11 +369,10 @@ index 3ea3116..7bb85c9 100644
  						}
  					}
  					let content = texts.join("\n\n");
-diff --git a/src/adapter/adapters/openai/streamer.rs b/src/adapter/adapters/openai/streamer.rs
-index 65d4d44..15b3a9d 100644
---- a/src/adapter/adapters/openai/streamer.rs
-+++ b/src/adapter/adapters/openai/streamer.rs
-@@ -100,6 +100,7 @@ impl futures::Stream for OpenAIStreamer {
+diff -ruN a/src/adapter/adapters/openai/streamer.rs b/src/adapter/adapters/openai/streamer.rs
+--- a/src/adapter/adapters/openai/streamer.rs	2025-12-16 02:09:31.457100031 +0000
++++ b/src/adapter/adapters/openai/streamer.rs	2025-12-16 02:07:15.840533215 +0000
+@@ -100,6 +100,7 @@
  							captured_text_content: self.captured_data.content.take(),
  							captured_reasoning_content: self.captured_data.reasoning_content.take(),
  							captured_tool_calls,
@@ -337,11 +380,10 @@ index 65d4d44..15b3a9d 100644
  						};
  
  						return Poll::Ready(Some(Ok(InterStreamEvent::End(inter_stream_end))));
-diff --git a/src/adapter/adapters/openai_resp/adapter_impl.rs b/src/adapter/adapters/openai_resp/adapter_impl.rs
-index 51fa543..a7f11d2 100644
---- a/src/adapter/adapters/openai_resp/adapter_impl.rs
-+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
-@@ -394,6 +394,8 @@ impl OpenAIRespAdapter {
+diff -ruN a/src/adapter/adapters/openai_resp/adapter_impl.rs b/src/adapter/adapters/openai_resp/adapter_impl.rs
+--- a/src/adapter/adapters/openai_resp/adapter_impl.rs	2025-12-16 02:09:31.458100042 +0000
++++ b/src/adapter/adapters/openai_resp/adapter_impl.rs	2025-12-16 02:07:15.840533215 +0000
+@@ -394,6 +394,8 @@
  								// TODO: Probably need to warn if it is a ToolCalls type of content
  								ContentPart::ToolCall(_) => (),
  								ContentPart::ToolResponse(_) => (),
@@ -350,7 +392,7 @@ index 51fa543..a7f11d2 100644
  							}
  						}
  						input_items.push(json! ({"role": "user", "content": values}));
-@@ -436,6 +438,8 @@ impl OpenAIRespAdapter {
+@@ -436,6 +438,8 @@
  							// TODO: Probably need towarn on this one (probably need to add binary here)
  							ContentPart::Binary(_) => (),
  							ContentPart::ToolResponse(_) => (),
@@ -359,10 +401,9 @@ index 51fa543..a7f11d2 100644
  						}
  					}
  
-diff --git a/src/adapter/adapters/support.rs b/src/adapter/adapters/support.rs
-index 98712f7..5f4e8b4 100644
---- a/src/adapter/adapters/support.rs
-+++ b/src/adapter/adapters/support.rs
+diff -ruN a/src/adapter/adapters/support.rs b/src/adapter/adapters/support.rs
+--- a/src/adapter/adapters/support.rs	2025-12-16 02:09:31.460100065 +0000
++++ b/src/adapter/adapters/support.rs	2025-12-16 02:07:15.841533226 +0000
 @@ -2,7 +2,7 @@
  //! It should be private to the `crate::adapter::adapters` module.
  
@@ -372,7 +413,7 @@ index 98712f7..5f4e8b4 100644
  use crate::resolver::AuthData;
  use crate::{Error, Result};
  
-@@ -46,6 +46,7 @@ pub struct StreamerCapturedData {
+@@ -46,6 +46,7 @@
  	pub content: Option<String>,
  	pub reasoning_content: Option<String>,
  	pub tool_calls: Option<Vec<crate::chat::ToolCall>>,
@@ -380,10 +421,9 @@ index 98712f7..5f4e8b4 100644
  }
  
  // endregion: --- Streamer Captured Data
-diff --git a/src/adapter/inter_stream.rs b/src/adapter/inter_stream.rs
-index 8b58ed5..3313131 100644
---- a/src/adapter/inter_stream.rs
-+++ b/src/adapter/inter_stream.rs
+diff -ruN a/src/adapter/inter_stream.rs b/src/adapter/inter_stream.rs
+--- a/src/adapter/inter_stream.rs	2025-12-16 02:09:31.464100111 +0000
++++ b/src/adapter/inter_stream.rs	2025-12-16 02:07:15.841533226 +0000
 @@ -5,7 +5,7 @@
  //!
  //! NOTE: This might be removed at some point as it may not be needed, and we could go directly to the GenAI stream.
@@ -393,7 +433,7 @@ index 8b58ed5..3313131 100644
  
  #[derive(Debug, Default)]
  pub struct InterStreamEnd {
-@@ -20,6 +20,9 @@ pub struct InterStreamEnd {
+@@ -20,6 +20,9 @@
  
  	// When `ChatOptions..capture_tool_calls == true`
  	pub captured_tool_calls: Option<Vec<crate::chat::ToolCall>>,
@@ -403,10 +443,9 @@ index 8b58ed5..3313131 100644
  }
  
  /// Intermediary StreamEvent
-diff --git a/src/chat/chat_stream.rs b/src/chat/chat_stream.rs
-index 15bf9d4..867b21b 100644
---- a/src/chat/chat_stream.rs
-+++ b/src/chat/chat_stream.rs
+diff -ruN a/src/chat/chat_stream.rs b/src/chat/chat_stream.rs
+--- a/src/chat/chat_stream.rs	2025-12-16 02:09:31.465100123 +0000
++++ b/src/chat/chat_stream.rs	2025-12-16 02:07:15.841533226 +0000
 @@ -1,5 +1,5 @@
  use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
 -use crate::chat::{MessageContent, ToolCall, Usage};
@@ -414,7 +453,7 @@ index 15bf9d4..867b21b 100644
  use futures::Stream;
  use serde::{Deserialize, Serialize};
  use std::pin::Pin;
-@@ -109,6 +109,10 @@ pub struct StreamEnd {
+@@ -109,6 +109,10 @@
  
  	/// Captured reasoning content if `ChatOptions.capture_reasoning` is enabled.
  	pub captured_reasoning_content: Option<String>,
@@ -425,7 +464,7 @@ index 15bf9d4..867b21b 100644
  }
  
  impl From<InterStreamEnd> for StreamEnd {
-@@ -136,6 +140,7 @@ impl From<InterStreamEnd> for StreamEnd {
+@@ -136,6 +140,7 @@
  			captured_usage: inter_end.captured_usage,
  			captured_content,
  			captured_reasoning_content: inter_end.captured_reasoning_content,
@@ -433,11 +472,10 @@ index 15bf9d4..867b21b 100644
  		}
  	}
  }
-diff --git a/src/chat/content_part.rs b/src/chat/content_part.rs
-index 9b71d62..34cb5cc 100644
---- a/src/chat/content_part.rs
-+++ b/src/chat/content_part.rs
-@@ -21,6 +21,11 @@ pub enum ContentPart {
+diff -ruN a/src/chat/content_part.rs b/src/chat/content_part.rs
+--- a/src/chat/content_part.rs	2025-12-16 02:09:31.466100135 +0000
++++ b/src/chat/content_part.rs	2025-12-16 02:07:15.842533238 +0000
+@@ -21,6 +21,11 @@
  
  	#[from]
  	ToolResponse(ToolResponse),
@@ -449,7 +487,7 @@ index 9b71d62..34cb5cc 100644
  }
  
  /// Constructors
-@@ -136,6 +141,24 @@ impl ContentPart {
+@@ -136,6 +141,24 @@
  			None
  		}
  	}
@@ -474,7 +512,7 @@ index 9b71d62..34cb5cc 100644
  }
  
  /// is_.. Accessors
-@@ -179,6 +202,11 @@ impl ContentPart {
+@@ -179,6 +202,11 @@
  	pub fn is_tool_response(&self) -> bool {
  		matches!(self, ContentPart::ToolResponse(_))
  	}
@@ -486,7 +524,7 @@ index 9b71d62..34cb5cc 100644
  }
  
  // endregion: --- Content Part
-@@ -255,6 +283,30 @@ pub enum BinarySource {
+@@ -255,6 +283,30 @@
  
  // endregion: --- BinarySource
  
@@ -517,11 +555,10 @@ index 9b71d62..34cb5cc 100644
  // No `Local` location; this would require handling errors like "file not found" etc.
  // Such a file can be easily provided by the user as Base64, and we can implement a convenient
  // TryFrom<File> to Base64 version. All LLMs accept local images only as Base64.
-diff --git a/src/error.rs b/src/error.rs
-index 745e1b0..44b1469 100644
---- a/src/error.rs
-+++ b/src/error.rs
-@@ -118,6 +118,9 @@ pub enum Error {
+diff -ruN a/src/error.rs b/src/error.rs
+--- a/src/error.rs	2025-12-16 02:09:31.473100215 +0000
++++ b/src/error.rs	2025-12-16 02:07:15.842533238 +0000
+@@ -118,6 +118,9 @@
  	#[display("Reqwest EventSource error: {_0}")]
  	ReqwestEventSource(Box<reqwest_eventsource::Error>),
  


### PR DESCRIPTION
The genai library's AnthropicStreamer was not extracting cache_creation_input_tokens
and cache_read_input_tokens from the Anthropic API streaming response. This patch adds:

- Import of PromptTokensDetails in the streamer
- Extraction of cache_creation_input_tokens and cache_read_input_tokens paths
- Population of prompt_tokens_details.cache_creation_tokens and cached_tokens

This enables proper tracking of Anthropic prompt caching in streaming responses.