### PR TITLE
Fix read file tool to respect start_line and end_line parameters

### DIFF
--- a/src/tools/handlers.rs
+++ b/src/tools/handlers.rs
@@ -166,12 +166,14 @@ impl EffectHandler for Error {
 /// Read a file with line numbers
 pub struct ReadFile {
     pub path: PathBuf,
+    pub start_line: Option<i32>,
+    pub end_line: Option<i32>,
 }
 
 #[async_trait::async_trait]
 impl EffectHandler for ReadFile {
     async fn call(self: Box<Self>) -> Step {
-        match io::read_file(&self.path) {
+        match io::read_file(&self.path, self.start_line, self.end_line) {
             Ok(content) => Step::Output(content),
             Err(e) => Step::Error(e),
         }

--- a/src/tools/impls/read_file.rs
+++ b/src/tools/impls/read_file.rs
@@ -103,9 +103,7 @@ pub struct ReadFileTool;
 #[derive(Debug, Deserialize)]
 struct ReadFileParams {
     path: String,
-    #[allow(dead_code)]
     start_line: Option<i32>,
-    #[allow(dead_code)]
     end_line: Option<i32>,
 }
 
@@ -156,7 +154,11 @@ impl Tool for ReadFileTool {
         ToolPipeline::new()
             .then(handlers::ValidateFile { path: path.clone() })
             .await_approval()
-            .then(handlers::ReadFile { path })
+            .then(handlers::ReadFile {
+                path,
+                start_line: parsed.start_line,
+                end_line: parsed.end_line,
+            })
     }
 
     fn create_block(&self, call_id: &str, params: serde_json::Value) -> Box<dyn Block> {
@@ -230,8 +232,6 @@ mod tests {
         let file_path = dir.path().join("test.txt");
         fs::write(&file_path, "line 1\nline 2\nline 3\nline 4\nline 5\n").unwrap();
 
-        // Note: Line range filtering is not yet implemented in the effect interpreter
-        // This test just verifies the pipeline executes successfully
         let mut registry = ToolRegistry::empty();
         registry.register(std::sync::Arc::new(ReadFileTool));
         let mut executor = ToolExecutor::new(registry);
@@ -248,8 +248,53 @@ mod tests {
             decision: ToolDecision::Approve,
         }]);
 
-        if let Some(crate::tools::ToolEvent::Completed { .. }) = executor.next().await {
-            // success
+        if let Some(crate::tools::ToolEvent::Completed { content, .. }) = executor.next().await {
+            // Should contain lines 2-4 only
+            assert!(content.contains("line 2"), "Should contain line 2");
+            assert!(content.contains("line 3"), "Should contain line 3");
+            assert!(content.contains("line 4"), "Should contain line 4");
+            // Should NOT contain lines 1 or 5
+            assert!(!content.contains("line 1"), "Should not contain line 1");
+            assert!(!content.contains("line 5"), "Should not contain line 5");
+            // Line numbers should be correct (2, 3, 4 not 1, 2, 3)
+            assert!(content.contains("   2│line 2"), "Line 2 should be numbered as 2");
+            assert!(content.contains("   3│line 3"), "Line 3 should be numbered as 3");
+            assert!(content.contains("   4│line 4"), "Line 4 should be numbered as 4");
+        } else {
+            panic!("Expected Completed event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_file_with_end_of_file_marker() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+        fs::write(&file_path, "line 1\nline 2\nline 3\nline 4\nline 5\n").unwrap();
+
+        let mut registry = ToolRegistry::empty();
+        registry.register(std::sync::Arc::new(ReadFileTool));
+        let mut executor = ToolExecutor::new(registry);
+
+        executor.enqueue(vec![ToolCall {
+            agent_id: 0,
+            call_id: "test".to_string(),
+            name: ReadFileTool::NAME.to_string(),
+            params: json!({
+                "path": file_path.to_str().unwrap(),
+                "start_line": 3,
+                "end_line": -1  // Read to end of file
+            }),
+            decision: ToolDecision::Approve,
+        }]);
+
+        if let Some(crate::tools::ToolEvent::Completed { content, .. }) = executor.next().await {
+            // Should contain lines 3-5
+            assert!(content.contains("line 3"), "Should contain line 3");
+            assert!(content.contains("line 4"), "Should contain line 4");
+            assert!(content.contains("line 5"), "Should contain line 5");
+            // Should NOT contain lines 1 or 2
+            assert!(!content.contains("line 1"), "Should not contain line 1");
+            assert!(!content.contains("line 2"), "Should not contain line 2");
         } else {
             panic!("Expected Completed event");
         }


### PR DESCRIPTION
Two bugs were fixed:
1. The start_line and end_line parameters were parsed but never used -
   they were marked #[allow(dead_code)] and not passed to the handler
2. Even if line filtering was implemented, line numbers would show 1, 2, 3
   instead of the actual file line numbers

Changes:
- Updated io::read_file() to accept optional start_line and end_line params
- Updated ReadFile handler to pass line range parameters
- Updated ReadFileTool::compose() to pass params from the parsed request
- Added proper tests verifying both line filtering and correct numbering