### PR TITLE
Add SYSTEM.md prompt append feature

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -329,9 +329,14 @@ impl Config {
         Ok(Config::default())
     }
 
+    /// Get the config directory path (~/.config/codey)
+    pub fn config_dir() -> Option<PathBuf> {
+        dirs::home_dir().map(|p| p.join(".config").join("codey"))
+    }
+
     /// Get the default config file path
     pub fn default_config_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|p| p.join(".config").join("codey").join("config.toml"))
+        Self::config_dir().map(|p| p.join("config.toml"))
     }
 }
 


### PR DESCRIPTION
Append content from SYSTEM.md files to the built-in system prompt:
1. User-level: ~/.config/codey/SYSTEM.md
2. Project-level: .codey/SYSTEM.md

This allows users to customize agent behavior globally or per-project.

## Changes
- Add `Config::config_dir()` method for user config path
- Add `build_system_prompt()` function to assemble complete prompt

## Testing
- Created both user and project SYSTEM.md files
- Verified content appears in system prompt after restart