### PR TITLE
Support concurrent fetch_html browser sessions

### DIFF
--- a/src/tools/browser/mod.rs
+++ b/src/tools/browser/mod.rs
@@ -30,6 +30,7 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -44,6 +45,9 @@ use crate::config::BrowserConfig as AppBrowserConfig;
 
 /// Browser configuration context, initialized at app startup
 static BROWSER_CONTEXT: OnceLock<BrowserContext> = OnceLock::new();
+
+/// Monotonic counter for unique per-session temp directory names
+static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Context for browser-based tools (fetch_html, fetch_screenshot)
 #[derive(Debug, Clone)]
@@ -242,10 +246,15 @@ async fn fetch_with_browser(
     {
         let source_profile = std::path::Path::new(data_dir).join(prof);
         if source_profile.exists() {
-            // Use PID to isolate temp dirs between concurrent Codey instances
-            let temp_base =
-                std::env::temp_dir().join(format!("codey-browser-{}", std::process::id()));
-            // Clean up any previous temp dir to ensure fresh copy
+            // Use PID + monotonic counter to isolate temp dirs between
+            // concurrent browser sessions within the same process
+            let session_id = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let temp_base = std::env::temp_dir().join(format!(
+                "codey-browser-{}-{}",
+                std::process::id(),
+                session_id
+            ));
+            // Clean up any leftover temp dir from a previous run with same PID
             if temp_base.exists() {
                 let _ = std::fs::remove_dir_all(&temp_base);
             }
@@ -387,9 +396,14 @@ async fn fetch_with_browser(
     })
     .await;
 
-    // Clean up
+    // Clean up browser
     let _ = browser.close().await;
     handle.abort();
+
+    // Clean up temp profile directory
+    if let Some(ref temp) = temp_dir {
+        let _ = std::fs::remove_dir_all(temp);
+    }
 
     match page_result {
         Ok(Ok(html)) => Ok(html),

--- a/src/tools/browser/mod.rs
+++ b/src/tools/browser/mod.rs
@@ -35,6 +35,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use chromiumoxide::browser::{Browser, BrowserConfig, HeadlessMode};
+use chromiumoxide::cdp::browser_protocol::page::EventLifecycleEvent;
 use chromiumoxide::handler::viewport::Viewport;
 use futures::StreamExt;
 
@@ -379,15 +380,39 @@ async fn fetch_with_browser(
         }
     });
 
-    // Navigate to page
+    // Navigate to page and wait for network idle
     let page_result = tokio::time::timeout(Duration::from_secs(60), async {
+        // Create a blank page first so we can set up event listeners before navigation
         let page = browser
-            .new_page(url)
+            .new_page("about:blank")
+            .await
+            .map_err(|e| format!("Failed to create page: {}", e))?;
+
+        // Listen for lifecycle events (must be set up before navigation to catch all events)
+        let mut lifecycle_events = page
+            .event_listener::<EventLifecycleEvent>()
+            .await
+            .map_err(|e| format!("Failed to set up event listener: {}", e))?;
+
+        // Navigate to the target URL
+        page.goto(url)
             .await
             .map_err(|e| format!("Failed to navigate: {}", e))?;
 
-        // Wait for JavaScript to render (configurable for SPAs like Twitter)
-        tokio::time::sleep(Duration::from_millis(ctx.page_load_wait_ms)).await;
+        // Wait for networkIdle (no in-flight requests for 500ms).
+        // Falls back to timeout for pages with persistent connections (WebSockets, SSE).
+        let network_idle = async {
+            while let Some(event) = lifecycle_events.next().await {
+                if event.name == "networkIdle" {
+                    break;
+                }
+            }
+        };
+        let _ = tokio::time::timeout(
+            Duration::from_millis(ctx.page_load_wait_ms),
+            network_idle,
+        )
+        .await;
 
         // Get rendered HTML
         page.content()


### PR DESCRIPTION
Each fetch_with_browser call was using the same PID-based temp directory
(codey-browser-{PID}), so concurrent requests would destroy each other's
profile copies. Now uses a monotonic counter (PID + session_id) to give
each browser session its own isolated temp directory. Also cleans up
the temp directory after each session completes.

https://claude.ai/code/session_01VRxrdNTnNT3VtETntY4Gy6